### PR TITLE
New: added test case for filtering

### DIFF
--- a/selectors/dx/news.page.js
+++ b/selectors/dx/news.page.js
@@ -12,5 +12,16 @@ export default class NewsPage {
     this.loadMore = page.locator('[aria-label="Load more"]');
     this.firstCardDate = page.locator('.card-date').nth(0);
     this.lastCardDate = page.locator('.card-date').nth(5);
+
+    this.clearApplicationsFilter = page.locator('[aria-label="2"]');
+    this.clearSideBarFilterButtonTechnical = page.locator('[aria-label="Technical"]');
+  }
+
+  async expandFilterOptions(filterSection) {
+    await this.page.locator(`[aria-label="${filterSection}"]`).click();
+  }
+
+  async clickFilterOptions(filterOption) {
+    await this.page.locator(`sp-checkbox:text-is("${filterOption}")`).click();
   }
 }

--- a/tests/dx/news.test.js
+++ b/tests/dx/news.test.js
@@ -79,4 +79,65 @@ test.describe('Validate news block', () => {
       await expect(firstCardDate).toBeLessThan(lastCardDate);
     });
   });
+
+  test(`${features[2].name},${features[2].tags}`, async ({ page, baseURL }) => {
+    await test.step('Go to News page', async () => {
+      await page.goto(`${baseURL}${features[0].path}`);
+      await newsPage.firstCardTitle.waitFor({ state: 'visible', timeout: 30000 });
+      const result = await newsPage.resultNumber.textContent();
+      await expect(parseInt(result.split(' ')[0], 10)).toBeGreaterThan(6);
+    });
+
+    await test.step('Find all automation regression cards', async () => {
+      await newsPage.searchField.fill('Automation regression card');
+      const result = await newsPage.resultNumber.textContent();
+      await expect(parseInt(result.split(' ')[0], 10)).toBe(6);
+    });
+
+    await test.step('Test applications filter', async () => {
+      await newsPage.expandFilterOptions('Applications');
+      await newsPage.clickFilterOptions('Campaign');
+      const resultAfterCampaignFilterApplied = await newsPage.resultNumber.textContent();
+      await expect(parseInt(resultAfterCampaignFilterApplied.split(' ')[0], 10)).toBe(1);
+      await newsPage.clickFilterOptions('Analytics');
+      const resultAfterAnalyticsFilterApplied = await newsPage.resultNumber.textContent();
+      await expect(parseInt(resultAfterAnalyticsFilterApplied.split(' ')[0], 10)).toBe(2);
+      await newsPage.clearApplicationsFilter.click();
+      const resultAfterClearingApplicationsFilter = await newsPage.resultNumber.textContent();
+      await expect(parseInt(resultAfterClearingApplicationsFilter.split(' ')[0], 10)).toBe(6);
+      await newsPage.expandFilterOptions('Applications');
+    });
+
+    await test.step('Test audience filter', async () => {
+      await newsPage.expandFilterOptions('Audience');
+      await newsPage.clickFilterOptions('Technical');
+      const resultAfterTechnical = await newsPage.resultNumber.textContent();
+      await expect(parseInt(resultAfterTechnical.split(' ')[0], 10)).toBe(1);
+      await newsPage.clearSideBarFilterButtonTechnical.click();
+      const resultAfterClearingFilter = await newsPage.resultNumber.textContent();
+      await expect(parseInt(resultAfterClearingFilter.split(' ')[0], 10)).toBe(6);
+      await newsPage.expandFilterOptions('Audience');
+    });
+
+    await test.step('Test region filter', async () => {
+      await newsPage.expandFilterOptions('Region');
+      await newsPage.clickFilterOptions('Americas');
+      await newsPage.clickFilterOptions('Japan');
+      const resultAfterRegionFilters = await newsPage.resultNumber.textContent();
+      await expect(parseInt(resultAfterRegionFilters.split(' ')[0], 10)).toBe(3);
+      await newsPage.clickFilterOptions('Americas');
+      const resultAfterUncheckingAmericas = await newsPage.resultNumber.textContent();
+      await expect(parseInt(resultAfterUncheckingAmericas.split(' ')[0], 10)).toBe(1);
+    });
+
+    await test.step('Test topic filter', async () => {
+      await newsPage.expandFilterOptions('Topic');
+      await newsPage.clickFilterOptions('Solutions');
+      const resultAfterTopicFilter = await newsPage.resultNumber.textContent();
+      await expect(parseInt(resultAfterTopicFilter.split(' ')[0], 10)).toBe(1);
+      await newsPage.clearAllSelector.click();
+      const resultAfterClearingAllFilters = await newsPage.resultNumber.textContent();
+      await expect(parseInt(resultAfterClearingAllFilters.split(' ')[0], 10)).toBeGreaterThan(6);
+    });
+  });
 });


### PR DESCRIPTION
Testcase no3 filters:

1. go to https://main--dx-partners--adobecom.hlx.live/solutionpartners/drafts/automation/regression/partner-news
2. Expected to see more than 6 in results
3. in search field enter "Automation regression card"
4. Then i select filter applications:campaign
5. Expected to see 1 results: Automation regression card no5
6. Then i select filter applications:analytics
7. Expected to see 2 results: Automation regression card no5 and Automation regression card no2
8. Clear 2 filters from applications
9. Expected to see "6 results"
10. Then i select filter audience:technical
11. Expected to see 1 results: Automation regression card no4
12. Clear target filter below search
13. Expected to see "6 results"
14. Then i select filter region:americas and region:japan
15. Expected to see "3 results"
16. Uncheck region:americas
17. Expected to see "1 results"
18. Then i select filter topic:solutions
19. Expected to see "1 results"
20. Then i clear all
21. Expected to see more than 6 results